### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,8 @@ dependencies {
     include xplibs.context
     include xplibs.portal
     include xplibs.event
-    include( libs.lib.thymeleaf ) {
-        exclude group: 'com.enonic.xp'
-    }
-    include( libs.lib.http.client ) {
-        exclude group: 'com.enonic.xp'
-    }
+    include libs.lib.thymeleaf
+    include libs.lib.http.client
     include( libs.lib.cron ) {
         exclude group: 'com.enonic.xp'
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-http-client = "3.2.2"
+http-client = "4.0.0-SNAPSHOT"
 cron = "1.1.4"
 admin-ui = "6.0.0-A5"
 


### PR DESCRIPTION
## Summary

Follow-up cleanup that was missed in the prior `bump-enonic-libs` sweep.

### Version bumps (`gradle/libs.versions.toml`)

| Lib | Before | After |
|---|---|---|
| `http-client` | `3.2.2` | `4.0.0-SNAPSHOT` |

`thymeleaf` was already pinned at `3.0.0-SNAPSHOT` — no bump needed.

### Excludes dropped (`build.gradle`)

Removed the `{ exclude group: 'com.enonic.xp' }` clauses on `lib-thymeleaf` and `lib-http-client` — both libs were upgraded to target XP 8 directly, so the excludes are now no-ops.

### Excludes kept

`lib-cron` and `lib-admin-ui` are still on XP-7-era versions; their transitive XP deps would leak through `implementation` into the bundle. Their excludes stay (including the `devResources( libs.lib.admin.ui )` exclude).

## Audit

`./gradlew dependencies --configuration include --refresh-dependencies` confirms:
- `lib-thymeleaf:3.0.0-SNAPSHOT` and `lib-http-client:4.0.0-SNAPSHOT` resolve cleanly
- No `com.enonic.xp:*` transitive comes through either after the excludes are dropped
- `lib-cron` and `lib-admin-ui` still show their (excluded) XP transitives, hence keeping their excludes

## Test plan

- [x] `./gradlew clean build` is green locally
- [ ] CI green on the new branch tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)