### PR TITLE
Bump lib-cron and drop XP exclude

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,7 @@ dependencies {
     include xplibs.event
     include libs.lib.thymeleaf
     include libs.lib.http.client
-    include( libs.lib.cron ) {
-        exclude group: 'com.enonic.xp'
-    }
+    include libs.lib.cron
     include( libs.lib.admin.ui ) {
         exclude group: 'com.enonic.xp'
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
 http-client = "4.0.0-SNAPSHOT"
-cron = "1.1.4"
+cron = "2.0.0-SNAPSHOT"
 admin-ui = "6.0.0-A5"
 
 [libraries]


### PR DESCRIPTION
## Summary

Follow-up cleanup after #712 (XP 8 lib bump).

| Lib | Before | After |
|---|---|---|
| `lib-cron` | `1.1.4` | `2.0.0-SNAPSHOT` |

- Removed `exclude group: 'com.enonic.xp'` on lib-cron — redundant after XP 8 upgrade made its XP deps `compileOnly`.
- Kept excludes on `lib-admin-ui` (incl. `devResources`) — that lib is not yet upgraded for XP 8.

## Audit

`./gradlew dependencies --configuration include --refresh-dependencies` confirms:

```
+--- com.enonic.lib:lib-cron:2.0.0-SNAPSHOT
|    \--- com.cronutils:cron-utils:9.2.1
|         \--- org.slf4j:slf4j-api:2.0.7 -> 2.0.17
```

No `com.enonic.xp:*` transitives leak from lib-cron after dropping the exclude.

## Test plan

- [x] `./gradlew clean build` green locally
- [ ] CI green on this branch tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)