### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ projectName=siteimprove
 appName=com.enonic.app.siteimprove
 xpVersion=8.0.0-B4
 libAdminUiVersion=6.0.0-A5
-version=1.8.0-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Branch off the XP 7 maintenance line as `1.x` (created from `713428b3`, the first post-v1.7.0 SNAPSHOT commit) and bump master to the next major: `1.8.0-SNAPSHOT` → `2.0.0-SNAPSHOT`.
- Add a `releaseBranch:` block to `enonic-gradle.yml` listing both `master` and `1.x`, so pushes to either branch are recognized as release-branch builds.
- Companion PR on `1.x` adds the same workflow change there (the action reads `releaseBranch:` from the branch's own workflow file).

Reference: app-booster's master/1.x split.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, `./gradlew clean build` is green on master