### PR TITLE
refactor: simplify Siteimprove script injection in cms-plugin.js

### DIFF
--- a/src/main/resources/cms/processors/cms-plugin.js
+++ b/src/main/resources/cms/processors/cms-plugin.js
@@ -12,15 +12,7 @@ exports.responseProcessor = function (req, res) {
 
     const analyticsCode = siteConfig['analyticsCode'] ? siteConfig['analyticsCode'].trim() : '';
     if (analyticsCode !== '') {
-        var snippet = '<!-- Siteimprove -->';
-        snippet += '<script type="text/javascript">';
-        snippet += '(function() {';
-        snippet += 'var sz = document.createElement("script"); sz.type = "text/javascript"; sz.async = true;';
-        snippet += 'sz.src = "//siteimproveanalytics.com/js/siteanalyze_' + analyticsCode + '.js";';
-        snippet += 'var s = document.getElementsByTagName("script")[0]; s.parentNode.insertBefore(sz, s);';
-        snippet += '})();';
-        snippet += '</script>';
-        snippet += '<!-- End Siteimprove -->';
+        var snippet = `<!-- Siteimprove --><script async src="https://siteimproveanalytics.com/js/siteanalyze_${analyticsCode}.js"></script><!-- End Siteimprove -->`;
 
         var bodyEnd = res.pageContributions.bodyEnd;
         if (!bodyEnd) {


### PR DESCRIPTION
This PR simplifies the Siteimprove analytics script injection in `cms-plugin.js` by replacing the inline JavaScript with a direct `<script async src="...">` tag, as recommended in [Siteimprove's own documentation](https://help.siteimprove.com/support/solutions/articles/80000448448-adding-siteimprove-analytics-javascript-to-your-website#Adding-the-code-manually).

The main benefit is security: the current implementation requires `unsafe-inline` in the `script-src` CSP directive, which this change removes.